### PR TITLE
pkce flows for Oauth sign in, rpc changes, scope for logout

### DIFF
--- a/src/suplex/suplex.py
+++ b/src/suplex/suplex.py
@@ -765,9 +765,11 @@ class Suplex(rx.State):
                 - redirect_to: URL to redirect after authentication
                 - scopes: List of permission scopes to request
                 - query_params: Additional parameters to include in the OAuth request
+                - code_challenge: A random string used for PKCE to mitigate authorization code interception attacks.
+                - code_challenge_method: The method used to generate the code challenge. Must be either 'plain' or 's256'.
                 
         Returns:
-            A URL string to redirect the user to for OAuth authentication. When user 
+            A URL string to redirect the user to for OAuth authentication. When the user 
             successfully authenticates, they will be redirected back to the redirect_to URL.
             Parse the URL for the tokens and use set_tokens() to store them.
             
@@ -792,6 +794,10 @@ class Suplex(rx.State):
                 data["scopes"] = options.pop("scopes")
             if "query_params" in options:
                 data["query_params"] = options.pop("query_params")
+            if "code_challenge" in options:
+                data["code_challenge"] = options.pop("code_challenge")
+            if "code_challenge_method" in options:
+                data["code_challenge_method"] = options.pop("code_challenge_method")
 
         response = httpx.get(url, headers=headers, params=data)
 

--- a/src/suplex/suplex.py
+++ b/src/suplex/suplex.py
@@ -309,7 +309,7 @@ class Query(rx.Base):
                 raise ValueError("Must select columns to return or '*' to return all.")
             response = httpx.get(url, headers=headers, **kwargs)
         elif self._method == "post":
-            if not self._data:
+            if not self._data and "rpc" not in self._table:
                 raise ValueError("Missing data for request.")
             response = httpx.post(url, headers=headers, json=self._data, **kwargs)
         elif self._method == "put":
@@ -336,6 +336,10 @@ class Query(rx.Base):
         
         # Raise any HTTP errors
         response.raise_for_status()
+
+        # If the response is successful but empty
+        if not response.content:
+            return None
 
         # Return the response
         return response.json()
@@ -380,7 +384,7 @@ class Query(rx.Base):
                     raise ValueError("Must select columns to return or '*' to return all.")
                 response = await client.get(url, headers=headers, **kwargs)
             elif self._method == "post":
-                if not self._data:
+                if not self._data and "rpc" not in self._table:
                     raise ValueError("Missing data for request.")
                 response = await client.post(url, headers=headers, json=self._data, **kwargs)
             elif self._method == "put":
@@ -407,6 +411,10 @@ class Query(rx.Base):
             
             # Raise any HTTP errors
             response.raise_for_status()
+
+            # If the response is successful but empty
+            if not response.content:
+                return None
 
             # Return the response
             return response.json()


### PR DESCRIPTION
The Changes
- fixed exchange_code_for_session and added code challenge and code challenge method parameters to sign in with oauth so it's now possible to use the pkce flow for an Oauth sign-in
- rpc calls remote postgress functions. Functions don't necessarily take input or return responses. Made sure calling rpc wouldn't return errors if either of those happened.
- the logout API has options for the scope of the logout (e.g global or local) but this was previously not implemented. 